### PR TITLE
Implement FFmpeg image encoder

### DIFF
--- a/apps/web/src/__tests__/lib/ffmpeg-utils.test.ts
+++ b/apps/web/src/__tests__/lib/ffmpeg-utils.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from '@jest/globals'
+import { encodeImagesToVideo } from '@/lib/ffmpeg-utils'
+
+const tinyPngBase64 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z/C/HwAF/gO+6KdFMwAAAABJRU5ErkJggg=='
+
+const pngBytes = new Uint8Array(Buffer.from(tinyPngBase64, 'base64'))
+
+// Simple smoke test to ensure FFmpeg encoding pipeline executes
+// without throwing and returns a Blob instance.
+describe('encodeImagesToVideo', () => {
+  it('should encode small PNG frames into a video blob', async () => {
+    const frames = [
+      { name: 'frame-00000.png', data: pngBytes },
+      { name: 'frame-00001.png', data: pngBytes },
+      { name: 'frame-00002.png', data: pngBytes },
+    ]
+
+    const blob = await encodeImagesToVideo(frames, { fps: 1 })
+    expect(blob).toBeInstanceOf(Blob)
+    expect(blob.type).toContain('video/')
+  })
+})


### PR DESCRIPTION
## Summary
- add a helper in `ffmpeg-utils` to encode image sequences into a video
- add a smoke test for the new `encodeImagesToVideo` function

## Testing
- `bun test` *(fails: ReferenceError: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6875eab42788832c84ea9dea06f80744

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to encode a sequence of PNG images into a video file directly in the browser.
  * Supports specifying frame rate, output format (mp4 or webm), and progress updates during encoding.

* **Tests**
  * Introduced automated tests to verify that encoding images into a video completes successfully and returns a valid video file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->