### PR TITLE
Implement offline ffmpeg export

### DIFF
--- a/apps/web/src/__tests__/lib/ffmpeg-video-recorder.test.ts
+++ b/apps/web/src/__tests__/lib/ffmpeg-video-recorder.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from '@jest/globals'
+import { FFmpegVideoRecorder } from '@/lib/ffmpeg-video-recorder'
+import { createMockExportSettings } from '../utils/test-helpers'
+
+const tinyPngBase64 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z/C/HwAF/gO+6KdFMwAAAABJRU5ErkJggg=='
+
+const dataUrl = `data:image/png;base64,${tinyPngBase64}`
+
+describe('FFmpegVideoRecorder', () => {
+  it('should encode added frames into a video', async () => {
+    const settings = createMockExportSettings()
+    const recorder = new FFmpegVideoRecorder({ fps: 1, settings })
+
+    await recorder.startRecording()
+    await recorder.addFrame(dataUrl, 0)
+    await recorder.addFrame(dataUrl, 1)
+    const blob = await recorder.stopRecording()
+
+    expect(blob).toBeInstanceOf(Blob)
+    expect(blob.type).toContain('video/')
+  })
+})

--- a/apps/web/src/lib/ffmpeg-video-recorder.ts
+++ b/apps/web/src/lib/ffmpeg-video-recorder.ts
@@ -1,0 +1,55 @@
+import { ExportSettings } from "@/types/export";
+import { encodeImagesToVideo, ImageFrame } from "@/lib/ffmpeg-utils";
+
+export interface FFmpegVideoRecorderOptions {
+  fps: number;
+  settings: ExportSettings;
+}
+
+/**
+ * Offline video recorder that collects PNG frames and encodes
+ * them into a video using FFmpeg.wasm.
+ */
+export class FFmpegVideoRecorder {
+  private fps: number;
+  private settings: ExportSettings;
+  private frames: ImageFrame[] = [];
+
+  constructor(options: FFmpegVideoRecorderOptions) {
+    this.fps = options.fps;
+    this.settings = options.settings;
+  }
+
+  async startRecording(): Promise<void> {
+    // FFmpeg initialization is handled by encodeImagesToVideo
+    this.frames = [];
+  }
+
+  async addFrame(dataUrl: string, index: number): Promise<void> {
+    const base64 = dataUrl.split(",", 2)[1];
+    const data = new Uint8Array(Buffer.from(base64, "base64"));
+    const name = `frame-${String(index).padStart(5, "0")}.png`;
+    this.frames.push({ name, data });
+  }
+
+  async stopRecording(): Promise<Blob> {
+    const blob = await encodeImagesToVideo(this.frames, {
+      fps: this.fps,
+      format: this.settings.format,
+    });
+    this.frames = [];
+    return blob;
+  }
+
+  setAudioStream(_stream: MediaStream | null): void {
+    // Audio not yet supported for FFmpeg path
+  }
+
+  cleanup(): void {
+    this.frames = [];
+  }
+}
+
+export const isFFmpegExportEnabled = (): boolean => {
+  return process.env.NEXT_PUBLIC_OFFLINE_EXPORT === "true";
+};

--- a/o3_task4.md
+++ b/o3_task4.md
@@ -32,3 +32,9 @@ Add optional audio muxing (once video path is solid).
 B. Verify browser support – FFmpeg-wasm works but needs >150 MB memory; Safari requires "crossOriginIsolated" headers.
 C. If FFmpeg-wasm proves too heavy, fall back to a server-side encode or a streaming “pipe” using MediaStreamTrackGenerator (but that re-introduces timing issues).
 Let me know which step you’d like tackled first (e.g. “make a minimal FFmpeg encoder that turns 3 canvas snapshots into an MP4”), and I’ll implement it incrementally and test it rather than pasting a full-file replacement.
+
+Implemented solution:
+- Created `FFmpegVideoRecorder` to collect PNG frames and encode them using FFmpeg.
+- Added feature flag `NEXT_PUBLIC_OFFLINE_EXPORT` so the new recorder only runs when enabled.
+- ExportEngine renders frames sequentially with `renderFramesOffline` and feeds them to the recorder.
+- Added unit test for the new recorder to ensure frames are encoded to a video blob.


### PR DESCRIPTION
## Summary
- add `FFmpegVideoRecorder` for off‑line frame encoding
- switch `ExportEngine` to new recorder via `NEXT_PUBLIC_OFFLINE_EXPORT`
- render frames sequentially when using FFmpeg
- document implementation in `o3_task4.md`
- add unit test for FFmpeg recorder

## Testing
- `bun test` *(fails: Cannot find module '@playwright/test' and other setup issues)*

------
https://chatgpt.com/codex/tasks/task_e_6875ed8a4ff0832cbbc89cddaaaccf6b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced offline video export using FFmpeg, allowing video creation from PNG frames without relying on browser-based recording.
  * Added a feature flag to enable or disable offline export.
* **Tests**
  * Added unit tests to verify that offline video export produces valid video files.
* **Documentation**
  * Updated documentation to describe the new offline export functionality and feature flag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->